### PR TITLE
fixed incorrect content-type being sent

### DIFF
--- a/src/sentry_webhooks/plugin.py
+++ b/src/sentry_webhooks/plugin.py
@@ -82,6 +82,7 @@ class WebHooksPlugin(NotificationPlugin):
             data=data,
             timeout=self.timeout,
             user_agent=self.user_agent,
+            headers=(('Accept-Encoding', 'gzip'), ('Content-type', 'application/json')),
         )
 
     def notify_users(self, group, event, fail_silently=False):


### PR DESCRIPTION
safe_urlopen uses urllib2 which sets the content-type to `application/x-www-form-urlencoded` [by default](https://docs.python.org/2/library/urllib2.html#urllib2.Request). We are sending json encoded data, and so have to override the headers.
